### PR TITLE
Add footer with Quit and Toggle scan actions

### DIFF
--- a/TheengsExplorer/__init__.py
+++ b/TheengsExplorer/__init__.py
@@ -18,43 +18,49 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import asyncio
-
 from bleak import BleakScanner
 from textual.app import App
-from textual.widgets import ScrollView
+from textual.widgets import Footer, ScrollView
 from widgets.devicetable import DeviceTable
 
 
 class TheengsExplorerApp(App):
     """Textual app that shows BLE advertisements."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.scanner = BleakScanner()
+        self.scanner.register_detection_callback(self.detection_callback)
+        self.scanning = True
+
     async def detection_callback(self, device, advertisement_data) -> None:
         """Process detected advertisement data from device."""
         self.device_table.update_device(device, advertisement_data)
         await self.scroll_view.update(self.device_table.render(), home=False)
 
-    async def ble_scan(self) -> None:
-        """Register detection callback and start BLE scanner."""
-        scanner = BleakScanner()
-        scanner.register_detection_callback(self.detection_callback)
-        await scanner.start()
-        while True:
-            await asyncio.sleep(5.0)
-
     async def on_load(self) -> None:
         """Bind keys when the app loads."""
         await self.bind("q", "quit", "Quit")
-        await self.bind("escape", "quit", "Quit")
+        await self.bind("s", "toggle_scan", "Toggle scan")
+
+    async def action_toggle_scan(self) -> None:
+        """Start or stop BLE scanner."""
+        if self.scanning:
+            await self.scanner.stop()
+            self.scanning = False
+        else:
+            await self.scanner.start()
+            self.scanning = True
 
     async def on_mount(self) -> None:
         """Create ScrollView and start BLE scan."""
         self.device_table = DeviceTable()
         self.scroll_view = ScrollView(self.device_table)
 
+        await self.view.dock(Footer(), edge="bottom")
         await self.view.dock(self.scroll_view, edge="top")
 
-        asyncio.create_task(self.ble_scan())
+        await self.scanner.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description:

Adds a footer with actions to quit the app and toggle BLE scanning. This also fixes the warning that was shown when quitting the app.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
