### PR TITLE
Try to decode advertisement with service data for each UUID separately

### DIFF
--- a/TheengsExplorer/decoder.py
+++ b/TheengsExplorer/decoder.py
@@ -5,14 +5,11 @@ from TheengsDecoder import decodeBLE
 
 
 def decode(advertisement_data):
+    """Decode advertisement data with Theengs Decoder."""
     data_json = {}
 
-    if advertisement_data.service_data:
-        dstr = list(advertisement_data.service_data.keys())[0]
-        # TheengsDecoder only accepts 16 bit UUIDs, this converts the 128 bit UUID to 16 bit.
-        data_json["servicedatauuid"] = dstr[4:8]
-        dstr = str(list(advertisement_data.service_data.values())[0].hex())
-        data_json["servicedata"] = dstr
+    if advertisement_data.local_name:
+        data_json["name"] = advertisement_data.local_name
 
     if advertisement_data.manufacturer_data:
         dstr = str(
@@ -23,13 +20,25 @@ def decode(advertisement_data):
         dstr += str(list(advertisement_data.manufacturer_data.values())[0].hex())
         data_json["manufacturerdata"] = dstr
 
-    if advertisement_data.local_name:
-        data_json["name"] = advertisement_data.local_name
+    if advertisement_data.service_data:
+        # Try to decode advertisement with service data for each UUID separately.
+        for uuid, data in advertisement_data.service_data.items():
+            # TheengsDecoder only accepts 16 bit UUIDs, this converts the 128 bit UUID to 16 bit.
+            data_json["servicedatauuid"] = uuid[4:8]
+            data_json["servicedata"] = data.hex()
+            try:
+                # Return the first one that decodes correctly.
+                return json.loads(decodeBLE(json.dumps(data_json)))
+            except TypeError:
+                pass  # Just try the following UUID if Theengs Decoder can't decode the data.
+
+        # No UUID resulted in successful decoding.
+        return {}
 
     if data_json:
         try:
             data_json = json.loads(decodeBLE(json.dumps(data_json)))
-        except TypeError:  # Theengs Decoder can't decode the data
+        except TypeError:  # Theengs Decoder can't decode the data.
             data_json = {}
 
     return data_json


### PR DESCRIPTION
## Description:

Try to decode advertisement with service data for each UUID separately instead of only using the service data for the first found UUID. This makes it possible to reliably detect devices that advertise service data for multiple UUIDs, such as the RDL52832 (https://github.com/theengs/decoder/pull/138).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
