### PR TITLE
Only use BlueZ-specific passive scanning on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ optional arguments:
                         Scanning mode (default: active)
 ```
 
-For passive scanning you need Linux kernel >= 5.10 and BlueZ >= 5.56 with experimental features enabled.
+Passive scanning only works on Windows or Linux kernel >= 5.10 and BlueZ >= 5.56 with experimental features enabled.
 
 To enable experimental features in BlueZ on a Linux distribution that uses systemd, run the following command:
 

--- a/TheengsExplorer/__init__.py
+++ b/TheengsExplorer/__init__.py
@@ -19,14 +19,17 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from argparse import ArgumentParser
+import platform
 
 from bleak import BleakScanner
-from bleak.assigned_numbers import AdvertisementDataType
-from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
-from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
 from textual.app import App
 from textual.widgets import Footer, ScrollView
 from widgets.devicetable import DeviceTable
+
+if platform.system() == "Linux":
+    from bleak.assigned_numbers import AdvertisementDataType
+    from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
+    from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
 
 
 class TheengsExplorerApp(App):
@@ -39,7 +42,7 @@ class TheengsExplorerApp(App):
 
         # Passive scanning with BlueZ needs at least one or_pattern.
         # The following matches all devices.
-        if config["scanning_mode"] == "passive":
+        if platform.system() == "Linux" and config["scanning_mode"] == "passive":
             scanner_kwargs["bluez"] = BlueZScannerArgs(
                 or_patterns=[
                     OrPattern(0, AdvertisementDataType.FLAGS, b"\x06"),


### PR DESCRIPTION
## Description:

Only use BlueZ-specific code for passive scanning if the system is running Linux.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
