### PR TITLE
Don't show manufacturer name for non-compliant devices

### DIFF
--- a/TheengsExplorer/widgets/advertisement.py
+++ b/TheengsExplorer/widgets/advertisement.py
@@ -9,10 +9,11 @@ from textual.widget import Widget
 class CompanyID(Widget):
     """Widget that shows company ID and name."""
 
-    def __init__(self, cic: int):
+    def __init__(self, cic: int, compliant: bool):
         """Initialize CompanyID widget."""
         super().__init__()
         self.cic = cic
+        self.compliant = compliant
 
     def render(self) -> Text:
         """Render CompanyID widget."""
@@ -21,9 +22,12 @@ class CompanyID(Widget):
         except KeyError:
             manufacturer_name = "Unknown"
 
-        return Text.assemble(
-            f"0x{self.cic:04x} (", (manufacturer_name, "green bold"), ")"
-        )
+        if self.compliant:
+            return Text.assemble(
+                f"0x{self.cic:04x} (", (manufacturer_name, "green bold"), ")"
+            )
+        else:
+            return Text(f"0x{self.cic:04x}")
 
 
 class HexData(Widget):
@@ -69,10 +73,11 @@ class UUID(Widget):
 class Advertisement(Widget):
     """Widget that shows raw advertisement data."""
 
-    def __init__(self, advertisement_data):
+    def __init__(self, advertisement_data, cid_compliant):
         """Initialize Advertisement widget."""
         super().__init__()
         self.advertisement_data = advertisement_data
+        self.cid_compliant = cid_compliant
 
     def render(self) -> Text:
         """Render Advertisement widget."""
@@ -98,7 +103,11 @@ class Advertisement(Widget):
             tree = Tree("manufacturer data:")
             for cic, data in self.advertisement_data.manufacturer_data.items():
                 tree.add(
-                    Text.assemble(CompanyID(cic).render(), ": ", HexData(data).render())
+                    Text.assemble(
+                        CompanyID(cic, self.cid_compliant).render(),
+                        ": ",
+                        HexData(data).render(),
+                    )
                 )
             table.add_row(tree)
 

--- a/TheengsExplorer/widgets/decoded.py
+++ b/TheengsExplorer/widgets/decoded.py
@@ -47,9 +47,9 @@ class Decoded(Widget):
         table = Table(show_header=False, show_edge=False, padding=0)
 
         if self.decoded:
-            # Remove tempf, as well as keys we already show in the Device widget
+            # Remove tempf, as well as keys we already show in the Device or Advertisement widgets
             decoded = self.decoded.copy()  # Make local copy before popping
-            for key in ["name", "brand", "model", "model_id", "tempf"]:
+            for key in ["name", "brand", "model", "model_id", "tempf", "cidc"]:
                 try:
                     decoded.pop(key)
                 except KeyError:

--- a/TheengsExplorer/widgets/devicetable.py
+++ b/TheengsExplorer/widgets/devicetable.py
@@ -45,7 +45,8 @@ class DeviceTable(Widget):
                 Decoded(info.decoded),
             ]
             if self.config["advertisement"]:
-                cells.append(Advertisement(info.advertisement_data))
+                cid_compliant = info.decoded.get("cidc", True)
+                cells.append(Advertisement(info.advertisement_data, cid_compliant))
 
             table.add_row(*cells)
         if table.rows:


### PR DESCRIPTION
## Description:

Don't show manufacturer name in Advertisement data column if the device is using a bogus company ID.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
