### PR TITLE
Don't show tempf_* keys in decoded data column

### DIFF
--- a/TheengsExplorer/widgets/decoded.py
+++ b/TheengsExplorer/widgets/decoded.py
@@ -47,13 +47,17 @@ class Decoded(Widget):
         table = Table(show_header=False, show_edge=False, padding=0)
 
         if self.decoded:
-            # Remove tempf, as well as keys we already show in the Device or Advertisement widgets
-            decoded = self.decoded.copy()  # Make local copy before popping
+            decoded = self.decoded.copy()  # Make local copy before deleting keys
+            # Remove tempf and keys we already show in the Device or Advertisement widgets
             for key in ["name", "brand", "model", "model_id", "tempf", "cidc"]:
                 try:
-                    decoded.pop(key)
+                    del decoded[key]
                 except KeyError:
                     pass
+            # Remove tempf_* keys
+            for key in list(decoded.keys()):
+                if key.startswith("tempf_"):
+                    del decoded[key]
 
             device_properties = json.loads(getProperties(self.decoded["model_id"]))[
                 "properties"


### PR DESCRIPTION
## Description:

Don't show tempf_* keys in decoded data column, for instance tempf_max and tempf_min for ThermoBeacon.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
