### PR TITLE
Add human-readable timestamps for ThermoBeacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Screenshot](screenshot.png)
 
-Theengs Explorer is still in early development. To try the development version, install its dependencies [Theengs Decoder](https://decoder.theengs.io/use/python.html), [Textual](https://github.com/Textualize/textual) and [bluetooth-numbers](https://github.com/koenvervloesem/bluetooth-numbers) and run it like this:
+Theengs Explorer is still in early development. To try the development version, install its dependencies [Theengs Decoder](https://decoder.theengs.io/use/python.html), [Textual](https://github.com/Textualize/textual), [bluetooth-numbers](https://github.com/koenvervloesem/bluetooth-numbers) and [humanize](https://github.com/python-humanize/humanize) and run it like this:
 
 ```shell
 python3 TheengsExplorer/__init__.py

--- a/TheengsExplorer/deviceinfo.py
+++ b/TheengsExplorer/deviceinfo.py
@@ -21,8 +21,12 @@ class DeviceInfo:
         self.previous_time = self.time
         self.time = datetime.now()
 
-        # Merge decoded data, with new data overriding previous data
         decoded = decode(advertisement_data)
+        # If advertisement contains timestamp, add current system time
+        if "time" in decoded:
+            decoded["system_time"] = int(datetime.now().timestamp())
+
+        # Merge decoded data, with new data overriding previous data
         if self.decoded:
             if decoded:
                 self.decoded = {**self.decoded, **decoded}

--- a/TheengsExplorer/widgets/decoded.py
+++ b/TheengsExplorer/widgets/decoded.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import json
 
+import humanize
 from rich.table import Table
 from rich.text import Text
 from textual.widget import Widget
@@ -51,10 +53,18 @@ class Decoded(Widget):
         table = Table(show_header=False, show_edge=False, padding=0)
 
         if self.decoded:
-            decoded = self.decoded.copy()  # Make local copy before deleting keys
+            decoded = self.decoded.copy()  # Make local copy before deleting keys and changing values
+
+            # Make timestamps human-readable
+            if "system_time" in decoded:
+                timedelta = int(datetime.now().timestamp()) - decoded["system_time"]
+                for key in decoded.keys():
+                    if key.startswith("time_"):
+                        decoded[key] = humanize.naturaltime(decoded["time"] - decoded[key] + timedelta)
+
             # Remove keys we already show in the Device or Advertisement widgets,
             # as well as tempf or tempc according to the user's chosen temperature unit.
-            for key in ["name", "brand", "model", "model_id", "cidc", self.hidden_temperature_unit]:
+            for key in ["name", "brand", "model", "model_id", "cidc", "time", "system_time", self.hidden_temperature_unit]:
                 try:
                     del decoded[key]
                 except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     package_dir={"TheengsExplorer": "TheengsExplorer"},
     packages=["TheengsExplorer"],
     include_package_data=True,
-    install_requires=["TheengsDecoder>=0.4.0", "textual>=0.1.15", "bluetooth-numbers>=0.1.1", "bleak>=0.15.0"],
+    install_requires=["TheengsDecoder>=0.4.0", "textual>=0.1.15", "bluetooth-numbers>=0.1.1", "bleak>=0.15.0", "humanize>=4.4.0"],
 )


### PR DESCRIPTION
## Description:

Shows human-readable timestamps for the maximal and minimal temperature of the ThermoBeacon, e.g. "a month ago", "15 minutes ago".

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
