### PR TITLE
Replace deprecated BleakScanner.register_detection_callback()

### DIFF
--- a/TheengsExplorer/__init__.py
+++ b/TheengsExplorer/__init__.py
@@ -53,9 +53,9 @@ class TheengsExplorerApp(App):
         if config["adapter"]:
             scanner_kwargs["adapter"] = config["adapter"]
 
-        self.scanner = BleakScanner(**scanner_kwargs)
+        scanner_kwargs["detection_callback"] = self.detection_callback
 
-        self.scanner.register_detection_callback(self.detection_callback)
+        self.scanner = BleakScanner(**scanner_kwargs)
         self.scanning = True
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Description:

As of Bleak 0.18.0 `BleakScanner.register_detection_callback()` has been deprecated, and it will be removed in a future Bleak version. This PR replaces the deprecated method call by the corresponding argument to the `BleakScanner` constructor.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
