### PR TITLE
Fix typo in README about daemon-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ExecStart=/usr/lib/bluetooth/bluetoothd --experimental
 Save and close the file and then run the following commands:
 
 ```
-sudo systemctl dameon-reload
+sudo systemctl daemon-reload
 sudo systemctl restart bluetooth.service
 ```
 


### PR DESCRIPTION
## Description:

Fixes typo in the README documentation about enabling passive scanning.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
